### PR TITLE
Properly sort issued certificate list & locale-based display.

### DIFF
--- a/src/app/organization/organization.component.html
+++ b/src/app/organization/organization.component.html
@@ -1,7 +1,5 @@
-<p>
-  organization works!
-</p>
 <div class="container container-grid">
+  <h1>Issued Certificates</h1>
   <ag-grid-angular 
     style="width: 500px; height: 500px;" 
     class="ag-theme-balham"

--- a/src/app/organization/organization.component.ts
+++ b/src/app/organization/organization.component.ts
@@ -16,15 +16,15 @@ export class OrganizationComponent implements OnInit {
 
     columnDefs = [
         {headerName: 'Student Name', field: 'name',checkboxSelection:true},
-        {headerName: 'Date', field: 'date' },
+        {headerName: 'Date', field: 'date', sort: 'desc', cellRenderer: (date) => date.value.toLocaleDateString() },
         {headerName: 'Certificate Description', field: 'desc'}
     ];
 
     rowData = [
-        { name: 'Chandler', date: '10/10/2018', desc: 'For being Sarcastic' },
-        { name: 'Joey', date: '10/10/2018', desc: 'For eating all the food' },
-        { name: 'Phoebe', date: '10/10/2018', desc: 'For being the normal one' }
+        { name: 'Phoebe', date: new Date('10/1/2018'), desc: 'For being the normal one' }
+        { name: 'Joey', date: new Date('10/2/2018'), desc: 'For eating all the food' },
+        { name: 'Chandler', date: new Date('10/3/2018'), desc: 'For being Sarcastic' },
     ];
 
-    
+
 }


### PR DESCRIPTION
Row data for organisation component's list of issued certificates stores an actual Date object as the issued date now. Used to sort the certificates newest first and also to have locale-specific display of dates. Also removed placeholder text.

Here's with the en_US locale:

![image](https://user-images.githubusercontent.com/4183876/48922080-0de1a280-ee9c-11e8-974b-2cd30d11b4db.png)

It's sorted by date descending initially, but you can still click on the headers to change that.

![image](https://user-images.githubusercontent.com/4183876/48922111-45504f00-ee9c-11e8-8289-af4743daf6f3.png)

(GCi task 6283509527216128)