### PR TITLE
Bulk file type & size validation

### DIFF
--- a/src/app/organization/organization.component.css
+++ b/src/app/organization/organization.component.css
@@ -15,6 +15,21 @@
   font-weight: bold;
 }
 
+#csvupload {
+  display:none;
+}
+.upload {
+  border: none;
+  background: #E91E63;
+  border-radius: 20px;
+  font-size: 100%;
+  font-weight: bold;
+  align-content: center;
+  text-align: center;
+  width: 30%;
+  color: white;
+}
+
 .rtl {
   float: right;
   text-align: right;

--- a/src/app/organization/organization.component.html
+++ b/src/app/organization/organization.component.html
@@ -10,6 +10,7 @@
     <div class="col rtl" >
       <h1 class="org-title"> Certificates: 8 </h1>
       <h4> Download </h4>
+        <label class="upload">BULK UPLOAD<input type="file" id="csvupload" accept=".csv" #input (change)="fileCSV()"></label>
     </div>
     <div class="container-fluid">
       <div class="row action-wrapper">

--- a/src/app/organization/organization.component.ts
+++ b/src/app/organization/organization.component.ts
@@ -7,6 +7,17 @@ import { Component, OnInit } from '@angular/core';
 })
 export class OrganizationComponent implements OnInit {
 
+  fileCSV(){
+    var csvSize = document.getElementById("csvupload").files[0];
+    if (csvSize.size > 5*1048576) // 5mb in bytes. 1 MB = 1048576 Bytes
+    {
+      alert("The File size should be less than 5MB!"); //Error Alert
+    }
+    else {
+      alert("File uploaded successfully!"); //Success Alert
+    }
+  }
+  
   constructor() { }
 
   ngOnInit() {


### PR DESCRIPTION
#### Bulk upload File type and size validation - JBoss Community
* The user can now only upload `.csv` files. User by default cannot select files with extensions other than `.csv` extension.
* [Video Link](https://drive.google.com/file/d/1Rax5sE5SwrkdS3cYGcfXOhxR3ETGrXAX/view?usp=sharing)
* [Task Link](https://codein.withgoogle.com/dashboard/task-instances/5867189706948608/)
![ezgif com-video-to-gif 3](https://user-images.githubusercontent.com/33092447/49464066-e84f8400-f81f-11e8-9081-c55b76047b0e.gif)
