### PR TITLE
Deploy to GH pages !!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,11 @@ before_script:
 script:
   - echo "Namaste! Travis this side"
   - echo "Note - I have not added   - ng test --watch false -cc & ng e2e in config file as then travis will show build fail"
-  - ng build
-  
+  - ng build --base-href https://JBossOutreach.github.io/certificate-generator-front/
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN
+  local_dir: dist/certificate-generator-front
+  on:
+    branch: master


### PR DESCRIPTION
Fixes https://github.com/JBossOutreach/certificate-generator-front/issues/250
Sample deployment - https://ananthavijay.github.io/certificate-generator-front/

- Generate a new GitHub token by going to this page https://github.com/settings/tokens
- It should have the scope ``repo``
- Then go Travis CI home page
- Go to certificate generator repo
- Go to settings
- Add an Environment Variable named ``GITHUB_TOKEN`` with the Token as the Value.
- Check it by making a simple commit
- It will create a branch named "gh pages"
- The app will be deployed on ``https://JBossOutreach.github.io/certificate-generator-front/``
- Credits: https://medium.com/angularmedellin/deploying-your-angular-app-to-github-pages-using-travis-ci-baca2e1c30e7

 Voila 🥂 